### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-cloudflare-zero-trust/config.go
+++ b/cmd/baton-cloudflare-zero-trust/config.go
@@ -22,11 +22,16 @@ var (
 		"email",
 		field.WithDescription("Cloudflare account email"),
 	)
+	baseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the Cloudflare API URL (for testing)"),
+	)
 	configurationFields = []field.SchemaField{
 		accountIdField,
 		apiKeyField,
 		apiTokenField,
 		emailField,
+		baseURLField,
 	}
 	fieldRelationships = []field.SchemaFieldRelationship{
 		field.FieldsAtLeastOneUsed(apiTokenField, apiKeyField),

--- a/cmd/baton-cloudflare-zero-trust/config.go
+++ b/cmd/baton-cloudflare-zero-trust/config.go
@@ -26,6 +26,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the Cloudflare API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 	configurationFields = []field.SchemaField{
 		accountIdField,

--- a/cmd/baton-cloudflare-zero-trust/config.go
+++ b/cmd/baton-cloudflare-zero-trust/config.go
@@ -25,6 +25,7 @@ var (
 	baseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the Cloudflare API URL (for testing)"),
+		field.WithHidden(true),
 	)
 	configurationFields = []field.SchemaField{
 		accountIdField,

--- a/cmd/baton-cloudflare-zero-trust/main.go
+++ b/cmd/baton-cloudflare-zero-trust/main.go
@@ -49,6 +49,7 @@ func getConnector(ctx context.Context, cfg *viper.Viper) (types.ConnectorServer,
 		cfg.GetString(apiTokenField.FieldName),
 		cfg.GetString(apiKeyField.FieldName),
 		cfg.GetString(emailField.FieldName),
+		cfg.GetString(baseURLField.FieldName),
 	)
 	if err != nil {
 		l.Error("error creating connector", zap.Error(err))

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -44,17 +44,23 @@ func (d *Connector) Validate(ctx context.Context) (annotations.Annotations, erro
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, accountId, apiToken, apiKey, email string) (*Connector, error) {
+func New(ctx context.Context, accountId, apiToken, apiKey, email, baseURL string) (*Connector, error) {
 	var (
 		client *cloudflare.API
 		err    error
 	)
+
+	var opts []cloudflare.Option
+	if baseURL != "" {
+		opts = append(opts, cloudflare.BaseURL(baseURL))
+	}
+
 	if apiKey != "" && email != "" {
-		client, err = cloudflare.New(apiKey, email)
+		client, err = cloudflare.New(apiKey, email, opts...)
 	}
 
 	if apiToken != "" {
-		client, err = cloudflare.NewWithAPIToken(apiToken)
+		client, err = cloudflare.NewWithAPIToken(apiToken, opts...)
 	}
 
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-cloudflare-zero-trust/config.go,cmd/baton-cloudflare-zero-trust/main.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-cloudflare-zero-trust --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom API endpoint base URL, enabling connection to alternate API environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->