### PR TITLE
fix: mark api-key and api-token as isSecret in config_schema

### DIFF
--- a/cmd/baton-cloudflare-zero-trust/config.go
+++ b/cmd/baton-cloudflare-zero-trust/config.go
@@ -13,10 +13,12 @@ var (
 	apiKeyField = field.StringField(
 		"api-key",
 		field.WithDescription("Cloudflare API key"),
+		field.WithIsSecret(true),
 	)
 	apiTokenField = field.StringField(
 		"api-token",
 		field.WithDescription("Cloudflare API token"),
+		field.WithIsSecret(true),
 	)
 	emailField = field.StringField(
 		"email",


### PR DESCRIPTION
The `api-key` and `api-token` config fields are Cloudflare API credentials but were defined as plain `field.StringField` with no `field.WithIsSecret(true)`, so neither was marked secret. This adds `WithIsSecret(true)` to both (matching baton-cloudflare, which marks the same fields). The `account-id` and `email` fields are identifiers and are correctly left unmarked.

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

_Built with stargate._
